### PR TITLE
Add integration and e2e tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2454,18 +2454,22 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cookiejar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
-      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/diff": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-5.2.3.tgz",
       "integrity": "sha512-K0Oqlrq3kQMaO2RhfrNQX5trmt+XLyom88zS0u84nnIcLvFnRUMRRHmrGny5GSM+kNO9IZLARsdQHDzkhAgmrQ==",
       "dev": true
+    },
+    "node_modules/@types/eventsource": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-3.0.0.tgz",
+      "integrity": "sha512-yEhFj31FTD29DtNeqePu+A+lD6loRef6YOM5XfN1kUwBHyy2DySGlA3jJU+FbQSkrfmlBVluf2Dub/OyReFGKA==",
+      "deprecated": "This is a stub types definition. eventsource provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource": "*"
+      }
     },
     "node_modules/@types/express": {
       "version": "5.0.0",
@@ -2542,13 +2546,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "node_modules/@types/methods": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
-      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -2569,6 +2566,17 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-3.0.3.tgz",
+      "integrity": "sha512-HhggYPH5N+AQe/OmN6fmhKmRRt2XuNJow+R3pQwJxOOF9GuwM7O2mheyGeIrs5MOIeNjDEdgdoyHBOrFeJBR3g==",
+      "deprecated": "This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -2609,29 +2617,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
-    },
-    "node_modules/@types/superagent": {
-      "version": "8.1.9",
-      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
-      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/cookiejar": "^2.1.5",
-        "@types/methods": "^1.1.4",
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/supertest": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.16.tgz",
-      "integrity": "sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/superagent": "*"
-      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -3980,6 +3965,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4427,6 +4422,30 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -4533,6 +4552,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/formidable": {
@@ -8960,6 +8992,46 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -10336,6 +10408,16 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10473,11 +10555,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "src/aws-kb-retrieval-server": {
@@ -10569,14 +10661,18 @@
         "mcp-server-everything": "dist/index.js"
       },
       "devDependencies": {
+        "@types/eventsource": "^3.0.0",
         "@types/express": "^5.0.0",
-        "@types/jest": "^29.5.3",
-        "@types/supertest": "^2.0.12",
-        "execa": "^8.0.1",
+        "@types/jest": "^29.5.12",
+        "@types/node-fetch": "^3.0.3",
+        "eventsource-parser": "^1.1.0",
+        "execa": "^8.0.0",
         "jest": "^29.7.0",
+        "node-fetch": "^3.3.2",
         "shx": "^0.3.4",
-        "supertest": "^6.3.3",
+        "supertest": "^6.3.4",
         "ts-jest": "^29.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "^5.6.2"
       }
     },
@@ -10907,6 +11003,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "src/everything/node_modules/eventsource-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-1.1.2.tgz",
+      "integrity": "sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "src/everything/node_modules/finalhandler": {
@@ -11568,24 +11674,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "src/everything/node_modules/zod": {
-      "version": "3.25.64",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.64.tgz",
-      "integrity": "sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "src/everything/node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     },
     "src/filesystem": {
@@ -12892,24 +12980,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "src/filesystem/node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "src/filesystem/node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     },
     "src/gdrive": {

--- a/src/everything/__tests__/e2e.smoke.test.ts
+++ b/src/everything/__tests__/e2e.smoke.test.ts
@@ -1,0 +1,89 @@
+import { execa } from 'execa';
+import fetch from 'node-fetch';
+import { createParser } from 'eventsource-parser';
+
+describe('E2E journey on Streamable HTTP', () => {
+  const PORT = '3103';
+  let server: execa.ExecaChildProcess;
+
+  beforeAll(async () => {
+    server = execa('node', [new URL('../dist/streamableHttp.js', import.meta.url).pathname], {
+      env: { PORT },
+      cwd: new URL('..', import.meta.url).pathname,
+      stderr: 'inherit'
+    });
+    await new Promise(r => setTimeout(r, 500));
+  });
+
+  afterAll(() => server.kill('SIGINT', { forceKillAfterTimeout: 1000 }));
+
+  const initSession = async () => {
+    const r = await fetch(`http://localhost:${PORT}/mcp`, {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '1.0',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0' }
+        }
+      }),
+      headers: {
+        'content-type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      }
+    });
+    return r.headers.get('mcp-session-id')!;
+  };
+
+  it('smoke, concurrency & resumability', async () => {
+    const sessionId = await initSession();
+
+    const longOp = (i: number) =>
+      fetch(`http://localhost:${PORT}/mcp`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'mcp-session-id': sessionId,
+          Accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 100 + i,
+          method: 'tools/call',
+          params: {
+            name: 'longRunningOperation',
+            arguments: { duration: 1, steps: 2 },
+            _meta: { progressToken: `tok-${i}` }
+          }
+        })
+      });
+
+    await Promise.all([...Array(10).keys()].map(longOp));
+
+    const stream1 = await fetch(`http://localhost:${PORT}/mcp`, {
+      method: 'GET',
+      headers: { 'mcp-session-id': sessionId, Accept: 'text/event-stream' }
+    });
+    let lastId = '';
+    const parser = createParser(ev => (lastId = ev.id ?? lastId));
+    for await (const chunk of stream1.body as any as AsyncIterable<Buffer>) {
+      parser.feed(chunk.toString());
+      if (lastId) break;
+    }
+    (stream1.body as any).destroy();
+
+    const stream2 = await fetch(`http://localhost:${PORT}/mcp`, {
+      method: 'GET',
+      headers: {
+        'mcp-session-id': sessionId,
+        'last-event-id': lastId,
+        Accept: 'text/event-stream'
+      }
+    });
+    expect(stream2.status).toBe(200);
+    (stream2.body as any).destroy();
+  }, 30000);
+});

--- a/src/everything/__tests__/sse.integration.test.ts
+++ b/src/everything/__tests__/sse.integration.test.ts
@@ -1,0 +1,48 @@
+import { execa } from 'execa';
+import fetch from 'node-fetch';
+
+describe('SSE transport (HTTP)', () => {
+  const PORT = '3101';
+  let server: execa.ExecaChildProcess;
+
+  beforeAll(async () => {
+    server = execa('node', [new URL('../dist/sse.js', import.meta.url).pathname], {
+      env: { PORT },
+      cwd: new URL('..', import.meta.url).pathname,
+      stderr: 'inherit'
+    });
+    await new Promise(r => setTimeout(r, 500));
+  });
+
+  afterAll(() => server.kill('SIGINT', { forceKillAfterTimeout: 1000 }));
+
+  it('handles GET /sse + POST /message', async () => {
+    const res = await fetch(`http://localhost:${PORT}/sse`);
+    expect(res.ok).toBeTruthy();
+
+    const firstChunk: Buffer = await new Promise(resolve =>
+      (res.body as any).once('data', (c: Buffer) => resolve(c))
+    );
+    const line = firstChunk.toString();
+    const match = line.match(/sessionId=([^\\n]+)/);
+    const sessionId = match ? match[1] : '';
+
+    expect(sessionId).not.toBe('');
+    const rpc = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'add', arguments: { a: 1, b: 2 } }
+    };
+
+    const r = await fetch(`http://localhost:${PORT}/message?sessionId=${sessionId}`,
+    {
+      method: 'POST',
+      body: JSON.stringify(rpc),
+      headers: { 'content-type': 'application/json' }
+    });
+    expect(r.status).toBe(202);
+
+    expect(sessionId).not.toBe('');
+  }, 15000);
+});

--- a/src/everything/__tests__/stdio.integration.test.ts
+++ b/src/everything/__tests__/stdio.integration.test.ts
@@ -1,0 +1,43 @@
+import { execa } from 'execa';
+import readline from 'node:readline';
+
+function jsonLine<T>(id: number, method: string, params: unknown = {}) {
+  return JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n';
+}
+
+describe('STDIO transport (child process)', () => {
+  const bin = new URL('../dist/index.js', import.meta.url).pathname;
+  let child: execa.ExecaChildProcess;
+
+  beforeAll(() => {
+    child = execa('node', [bin, 'stdio'], { cwd: new URL('..', import.meta.url).pathname });
+  });
+
+  afterAll(async () => {
+    child.kill('SIGINT', { forceKillAfterTimeout: 1000 });
+    await child;
+  });
+
+  const ask = async <T = unknown>(payload: string): Promise<T> => {
+    child.stdin!.write(payload);
+    const rl = readline.createInterface({ input: child.stdout! });
+    for await (const line of rl) {
+      const msg = JSON.parse(line) as T & { id?: number };
+      if ((msg as any).id === JSON.parse(payload).id) {
+        rl.close();
+        return msg;
+      }
+    }
+    throw new Error('No response');
+  };
+
+  it('lists tools & calls add', async () => {
+    const list = await ask<{ result: { tools: { name: string }[] } }>(jsonLine(1, 'tools/list'));
+    expect(list.result.tools.map(t => t.name)).toContain('add');
+
+    const add = await ask<{ result: { content: { text: string }[] } }>(
+      jsonLine(2, 'tools/call', { name: 'add', arguments: { a: 7, b: 3 } })
+    );
+    expect(add.result.content[0].text).toMatch('10');
+  }, 10000);
+});

--- a/src/everything/__tests__/streamable.integration.test.ts
+++ b/src/everything/__tests__/streamable.integration.test.ts
@@ -1,0 +1,58 @@
+import { execa } from 'execa';
+import fetch from 'node-fetch';
+
+describe('Streamable HTTP transport', () => {
+  const PORT = '3102';
+  let server: execa.ExecaChildProcess;
+
+  beforeAll(async () => {
+    server = execa('node', [new URL('../dist/streamableHttp.js', import.meta.url).pathname], {
+      env: { PORT },
+      cwd: new URL('..', import.meta.url).pathname,
+      stderr: 'inherit'
+    });
+    await new Promise(r => setTimeout(r, 500));
+  });
+
+  afterAll(() => server.kill('SIGINT', { forceKillAfterTimeout: 1000 }));
+
+  it('negotiates session + call echo', async () => {
+    const init = await fetch(`http://localhost:${PORT}/mcp`, {
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '1.0',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '1.0' }
+        }
+      }),
+      headers: {
+        'content-type': 'application/json',
+        Accept: 'application/json, text/event-stream'
+      }
+    });
+    const sessionId = init.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+
+    const echoReq = {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'echo', arguments: { message: 'hi' } }
+    };
+    const echoRes = await fetch(`http://localhost:${PORT}/mcp`, {
+      method: 'POST',
+      body: JSON.stringify(echoReq),
+      headers: {
+        'content-type': 'application/json',
+        'mcp-session-id': sessionId!,
+        Accept: 'application/json, text/event-stream'
+      }
+    }).then(r => r.json());
+
+    expect(echoRes.result.content[0].text).toBe('Echo: hi');
+  }, 10000);
+});

--- a/src/everything/jest.config.mjs
+++ b/src/everything/jest.config.mjs
@@ -15,6 +15,7 @@ export default {
     ...pathsToModuleNameMapper(compilerOptions.paths || {}, { prefix: '<rootDir>/' }),
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
+  testTimeout: 40000,
   globals: {
     'ts-jest': { useESM: true, diagnostics: false }
   }

--- a/src/everything/package.json
+++ b/src/everything/package.json
@@ -17,6 +17,7 @@
     "build": "tsc && shx cp instructions.md dist/ && shx chmod +x dist/*.js",
     "prepare": "npm run build",
     "watch": "tsc --watch",
+    "pretest": "npm run build",
     "start": "node dist/index.js",
     "start:sse": "node dist/sse.js",
     "start:streamableHttp": "node dist/streamableHttp.js",
@@ -31,11 +32,16 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
+    "@types/eventsource": "^3.0.0",
     "@types/jest": "^29.5.12",
+    "@types/node-fetch": "^3.0.3",
     "execa": "^8.0.0",
+    "eventsource-parser": "^1.1.0",
+    "node-fetch": "^3.3.2",
     "jest": "^29.7.0",
     "supertest": "^6.3.4",
     "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.2",
     "shx": "^0.3.4",
     "typescript": "^5.6.2"
   }


### PR DESCRIPTION
## Summary
- add pretest build and dev deps for integration tests
- extend Jest timeout
- add STDIO, SSE, and streamable HTTP transport tests
- add an end-to-end smoke test covering concurrency and resumability

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ee1770b80832f989797a3f0141b1f